### PR TITLE
Add self-update feature to sync-ssh-keys script and update documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,7 @@ This document provides comprehensive guidance for AI coding agents and contribut
   - Logging and error handling.
   - Configuration loading from `users.conf`.
   - A helper function `fetch_key_file` to handle key retrieval logic with retries for failed operations.
+  - A `--self-update` option to fetch and replace the script with the latest version from the GitHub repository.
 
 ### Configuration
 - **`users.conf`**: Defines users and their key sources. Example structure:
@@ -37,6 +38,10 @@ This document provides comprehensive guidance for AI coding agents and contribut
 2. Run the script manually:
    ```bash
    ./sync-ssh-keys.sh
+   ```
+3. To update the script to the latest version, run:
+   ```bash
+   ./sync-ssh-keys.sh --self-update
    ```
 
 ### Configuration
@@ -102,3 +107,8 @@ This document provides comprehensive guidance for AI coding agents and contribut
 - The `fetch_key_file` function includes a retry mechanism for failed fetch operations.
 - By default, it retries up to 3 times with a 2-second delay between attempts.
 - Logs detailed error messages for each failed attempt and skips the user if all retries fail.
+
+### Self-Update Feature
+- The `--self-update` option fetches the latest version of the script from the GitHub repository.
+- Replaces the current script with the downloaded version.
+- Ensures the script is always up-to-date with the latest features and fixes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,6 @@ jobs:
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
           generate_release_notes: true
-          files: ssh-key-sync.zip
+          files: |
+            ssh-key-sync.zip
+            sync-ssh-keys.sh

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This Bash script pulls `authorized_keys` files from remote URLs and updates SSH 
 - Safe: Only updates keys if they’ve changed
 - Logs activity per user
 - Retries failed fetch operations up to 3 times with a delay
+- **Self-update**: Automatically updates the script to the latest version from the GitHub repository
 
 ## ⚙️ Configuration
 
@@ -55,6 +56,10 @@ declare -A USER_KEYS=(
    ```cron
    */15 * * * * /usr/local/bin/sync-ssh-keys.sh >> /var/log/ssh-key-sync.log 2>&1
    ```
+5. To update the script to the latest version, run:
+   ```bash
+   ./sync-ssh-keys.sh --self-update
+   ```
 
 ## Implementation Notes
 
@@ -63,6 +68,7 @@ declare -A USER_KEYS=(
 - Includes a retry mechanism for failed fetch operations (3 attempts with a 2-second delay).
 - Only updates a user's `authorized_keys` if the remote file has changed.
 - Logs all actions with timestamps.
+- The `--self-update` option fetches the latest version of the script from the GitHub repository and replaces the current version.
 
 ## Examples
 

--- a/sync-ssh-keys.sh
+++ b/sync-ssh-keys.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # shellcheck disable=SC2034  # planned to be used in a future release
-SCRIPT_VERSION="0.0.8"
+SCRIPT_VERSION="0.0.9"
 
 # === Load user configuration ===
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
This pull request introduces a new `--self-update` feature to the `sync-ssh-keys.sh` script, allowing it to fetch and replace itself with the latest version from the GitHub repository. The changes include updates to the script, its documentation, and the release workflow to support this feature.

### New `--self-update` Feature

* **Script Implementation**: Added a `self_update` function in `sync-ssh-keys.sh` to fetch the latest version of the script from the GitHub repository, download it, and replace the current version. Includes error handling for failed updates. (`sync-ssh-keys.sh`, [sync-ssh-keys.shR59-R95](diffhunk://#diff-dfd0e16b4b051b8252d5253bf60ec6acc1c8d8fc2c026fc1148be1ef4ab8da8cR59-R95))
* **Documentation Updates**:
  - Updated `.github/copilot-instructions.md` to describe the `--self-update` option and provide usage instructions. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R17) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R42-R45) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R110-R114)
  - Updated `README.md` to highlight the self-update feature and include examples of how to use it. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R59-R62) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71)

### Release Workflow Update

* **Release Files**: Modified `.github/workflows/release.yml` to include `sync-ssh-keys.sh` as part of the release assets, ensuring the latest script version is available for updates.