### PR TITLE
Redirect log_info output to stderr for improved error visibility in g…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Lint Status](https://img.shields.io/github/actions/workflow/status/locus313/ssh-key-sync/lint.yml?style=flat-square&label=lint)](https://github.com/locus313/ssh-key-sync/actions)
 [![License](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](LICENSE)
 [![Shell](https://img.shields.io/badge/Shell-Bash-green?style=flat-square&logo=gnu-bash)](https://www.gnu.org/software/bash/)
-[![Version](https://img.shields.io/badge/Version-0.1.1-orange?style=flat-square)](https://github.com/locus313/ssh-key-sync/releases)
+[![Version](https://img.shields.io/badge/Version-0.1.2-orange?style=flat-square)](https://github.com/locus313/ssh-key-sync/releases)
 
 ⭐ If you like this project, star it on GitHub — it helps a lot!
 

--- a/sync-ssh-keys.sh
+++ b/sync-ssh-keys.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Repository: https://github.com/locus313/ssh-key-sync
 
 # shellcheck disable=SC2034  # planned to be used in a future release
-readonly SCRIPT_VERSION="0.1.1"
+readonly SCRIPT_VERSION="0.1.2"
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
 


### PR DESCRIPTION
This pull request updates the project version from 0.1.1 to 0.1.2 and makes a minor improvement to logging in the `sync-ssh-keys.sh` script.

Version bump:

* Updated the displayed version badge in `README.md` to 0.1.2.
* Changed the `SCRIPT_VERSION` variable in `sync-ssh-keys.sh` to 0.1.2.

Logging improvement:

* Redirected the "Fetching latest release information..." log message to standard error in the `get_latest_release_url` function in `sync-ssh-keys.sh`.…et_latest_release_url function