### PR TITLE
Fix reusable workflow configuration

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -8,6 +8,7 @@ on:
       - 'sync-ssh-keys.sh'
       - 'users.conf'
       - '.github/workflows/check-version.yml'
+  workflow_call:
 
 jobs:
   check-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   # Final status check
   ci-success:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, version-check]
     if: always()
     steps:
       - name: Check all jobs status

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ on:
       - 'sync-ssh-keys.sh'
       - 'users.conf'
       - '.github/workflows/lint.yml'
+  workflow_call:
 
 jobs:
   shellcheck:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ on:
       - 'sync-ssh-keys.sh'
       - 'users.conf'
       - '.github/workflows/test.yml'
+  workflow_call:
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Test Status](https://img.shields.io/github/actions/workflow/status/locus313/ssh-key-sync/ci.yml?style=flat-square&label=tests)](https://github.com/locus313/ssh-key-sync/actions)
 [![License](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](LICENSE)
 [![Shell](https://img.shields.io/badge/Shell-Bash-green?style=flat-square&logo=gnu-bash)](https://www.gnu.org/software/bash/)
-[![Version](https://img.shields.io/badge/Version-0.1.3-orange?style=flat-square)](https://github.com/locus313/ssh-key-sync/releases)
+[![Version](https://img.shields.io/badge/Version-0.1.4-orange?style=flat-square)](https://github.com/locus313/ssh-key-sync/releases)
 
 ⭐ If you like this project, star it on GitHub — it helps a lot!
 

--- a/sync-ssh-keys.sh
+++ b/sync-ssh-keys.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Repository: https://github.com/locus313/ssh-key-sync
 
 # shellcheck disable=SC2034  # planned to be used in a future release
-readonly SCRIPT_VERSION="0.1.3"
+readonly SCRIPT_VERSION="0.1.4"
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
 


### PR DESCRIPTION
This pull request updates the project version to 0.1.4 and makes several improvements to the GitHub Actions workflows by enabling them to be called as reusable workflows. Additionally, it ensures that the CI workflow properly waits for the version check job before reporting success.

Version bump:

* Updated the version number from 0.1.3 to 0.1.4 in both the `README.md` badge and the `SCRIPT_VERSION` variable in `sync-ssh-keys.sh`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7) [[2]](diffhunk://#diff-dfd0e16b4b051b8252d5253bf60ec6acc1c8d8fc2c026fc1148be1ef4ab8da8cL10-R10)

GitHub Actions improvements:

* Added `workflow_call` triggers to `.github/workflows/check-version.yml`, `.github/workflows/lint.yml`, and `.github/workflows/test.yml` to allow these workflows to be used as reusable workflows. [[1]](diffhunk://#diff-8afe568f7bca31f3457ff9b8e7fc829ac3918722cb3c77aa85b59c197b113664R11) [[2]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R18) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R21)
* Modified the `ci.yml` workflow so that the final status check (`ci-success` job) depends on the `version-check` job in addition to `lint` and `test`, ensuring all required checks are complete.- Add workflow_call trigger to check-version.yml, lint.yml, and test.yml
- Enable these workflows to be called by ci.yml as reusable workflows
- Resolve GitHub Actions workflow validation error