### PR TITLE
Add user GID retrieval for SSH ownership management

### DIFF
--- a/sync-ssh-keys.sh
+++ b/sync-ssh-keys.sh
@@ -324,10 +324,28 @@ get_user_home() {
   echo "$user_home"
 }
 
+get_user_gid() {
+  local username="$1"
+  local user_gid
+  
+  if ! user_gid=$(getent passwd "$username" | cut -d: -f4); then
+    log_error "Failed to get GID for user '$username'"
+    return 1
+  fi
+  
+  if [[ -z "$user_gid" ]]; then
+    log_error "Failed to determine GID for user '$username'"
+    return 1
+  fi
+  
+  echo "$user_gid"
+}
+
 # Create SSH directory with proper permissions
 create_ssh_directory() {
   local username="$1"
   local ssh_dir="$2"
+  local user_gid
   
   if [[ -d "$ssh_dir" ]]; then
     return 0
@@ -340,7 +358,11 @@ create_ssh_directory() {
     return 1
   fi
   
-  if ! chown "$username:$username" "$ssh_dir"; then
+  if ! user_gid=$(get_user_gid "$username"); then
+    return 1
+  fi
+  
+  if ! chown "$username:$user_gid" "$ssh_dir"; then
     log_error "Failed to set ownership of .ssh directory for user '$username'"
     return 1
   fi
@@ -358,6 +380,7 @@ update_authorized_keys() {
   local username="$1"
   local temp_file="$2"
   local auth_keys_file="$3"
+  local user_gid
   
   # Check if update is needed by comparing files
   if [[ -f "$auth_keys_file" ]] && files_are_identical "$temp_file" "$auth_keys_file"; then
@@ -377,7 +400,11 @@ update_authorized_keys() {
     return 1
   fi
   
-  if ! chown "$username:$username" "$auth_keys_file"; then
+  if ! user_gid=$(get_user_gid "$username"); then
+    return 1
+  fi
+  
+  if ! chown "$username:$user_gid" "$auth_keys_file"; then
     log_error "Failed to set ownership of authorized_keys file for user '$username'"
     return 1
   fi

--- a/sync-ssh-keys.sh
+++ b/sync-ssh-keys.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Repository: https://github.com/locus313/ssh-key-sync
 
 # shellcheck disable=SC2034  # planned to be used in a future release
-readonly SCRIPT_VERSION="0.1.5"
+readonly SCRIPT_VERSION="0.1.6"
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
 


### PR DESCRIPTION
This pull request improves the way file ownership is set for SSH directories and authorized keys files in the `sync-ssh-keys.sh` script. Instead of assuming the group name matches the username, it now dynamically retrieves the user's primary group ID (GID) to ensure correct ownership, which increases compatibility with systems where group names differ from usernames.

**Ownership handling improvements:**

* Added a new `get_user_gid()` function to retrieve the primary group ID (GID) for a given username, with error handling if the GID cannot be determined.
* Updated the `create_ssh_directory()` and `update_authorized_keys()` functions to use the actual GID (via `get_user_gid`) instead of assuming the group name is the same as the username when setting ownership with `chown`. [[1]](diffhunk://#diff-dfd0e16b4b051b8252d5253bf60ec6acc1c8d8fc2c026fc1148be1ef4ab8da8cL343-R365) [[2]](diffhunk://#diff-dfd0e16b4b051b8252d5253bf60ec6acc1c8d8fc2c026fc1148be1ef4ab8da8cL380-R407)
* Ensured that the new GID retrieval is used consistently by introducing the `user_gid` variable in relevant functions.