### PR TITLE
Update script version to 0.1.7 and redirect logs to stderr

### DIFF
--- a/sync-ssh-keys.sh
+++ b/sync-ssh-keys.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Repository: https://github.com/locus313/ssh-key-sync
 
 # shellcheck disable=SC2034  # planned to be used in a future release
-readonly SCRIPT_VERSION="0.1.6"
+readonly SCRIPT_VERSION="0.1.7"
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
 
@@ -38,13 +38,13 @@ log_error() {
 # Log warning messages
 log_warning() {
   local message="$1"
-  log_message "WARNING: $message"
+  log_message "WARNING: $message" >&2
 }
 
 # Log info messages
 log_info() {
   local message="$1"
-  log_message "INFO: $message"
+  log_message "INFO: $message" >&2
 }
 
 # === Configuration Loading ===


### PR DESCRIPTION
This pull request makes minor improvements to the logging behavior in the `sync-ssh-keys.sh` script and updates the script version number.

*Version update:*

- Bumped the `SCRIPT_VERSION` from `0.1.6` to `0.1.7` in `sync-ssh-keys.sh` to reflect the new changes.

*Logging improvements:*

- Modified the `log_warning` and `log_info` functions in `sync-ssh-keys.sh` to send their output to standard error (`stderr`) instead of standard output, ensuring that warnings and informational messages are properly separated from regular output.