### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ name: Test SSH Key Sync
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/locus313/ssh-key-sync/security/code-scanning/9](https://github.com/locus313/ssh-key-sync/security/code-scanning/9)

Add an explicit top-level `permissions` block to `.github/workflows/test.yml` so all jobs inherit the least privileges required.

Best fix (without changing behavior): define:

- `permissions:`
  - `contents: read`

at the workflow root, after the `on:` section and before `jobs:`. This is sufficient for `actions/checkout` and read-only test execution. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
