### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   # Run all individual checks in parallel
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/locus313/ssh-key-sync/security/code-scanning/7](https://github.com/locus313/ssh-key-sync/security/code-scanning/7)

Add a root-level `permissions` block in `.github/workflows/ci.yml` so all jobs in this workflow (including `ci-success` and reusable-workflow calls that don’t override permissions) inherit restricted token scopes by default.

Best fix here without changing functionality:
- Insert `permissions:` near the top level (after triggers and before `jobs:`).
- Set minimal read-only permissions:
  - `contents: read`
  - `packages: read`
This documents intent and prevents accidental broad token rights if repository defaults are permissive or change later.

No imports, methods, or extra definitions are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
