### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - 'users.conf'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/locus313/ssh-key-sync/security/code-scanning/5](https://github.com/locus313/ssh-key-sync/security/code-scanning/5)

Add an explicit `permissions` block in `.github/workflows/release.yml` to enforce least privilege.

Best single fix (without changing functionality): define workflow-level permissions right after `on:` so all jobs inherit it. This workflow needs:
- `contents: write` (required for pushing tags and creating releases)
No additional scopes are required by the shown steps.

Edit region:
- `.github/workflows/release.yml`, insert `permissions:` between `on:` block and `jobs:` block.

No imports, methods, or dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
