### PR TITLE
Update version badge and clarify testing section headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI Status](https://img.shields.io/github/actions/workflow/status/locus313/ssh-key-sync/ci.yml?style=flat-square&label=CI)](https://github.com/locus313/ssh-key-sync/actions)
 [![License](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](LICENSE)
 [![Bash](https://img.shields.io/badge/Bash-5.0+-green?style=flat-square&logo=gnu-bash)](https://www.gnu.org/software/bash/)
-[![Version](https://img.shields.io/badge/Version-0.1.8-orange?style=flat-square)](https://github.com/locus313/ssh-key-sync/releases)
+[![Version](https://img.shields.io/github/v/release/locus313/ssh-key-sync?style=flat-square&label=Version&color=orange)](https://github.com/locus313/ssh-key-sync/releases)
 
 *Synchronize SSH authorized_keys for multiple users from various sources*
 
@@ -244,6 +244,9 @@ For accessing private repositories, you'll need a GitHub Personal Access Token:
 
 ## Automation
 
+> [!NOTE]
+> The script loads `users.conf` from the same directory as `sync-ssh-keys.sh`. When deploying to a path like `/opt/ssh-key-sync/`, ensure `users.conf` is placed in that same directory.
+
 ### Production Deployment with Cron
 
 Set up automated synchronization for production environments:
@@ -282,8 +285,8 @@ Create a robust systemd service with automatic restart and monitoring:
    # Security settings
    NoNewPrivileges=true
    ProtectSystem=strict
-   ProtectHome=true
-   ReadWritePaths=/home /root
+   ProtectHome=true            # Makes home directories inaccessible by default
+   ReadWritePaths=/home /root  # Re-opens /home and /root so the script can write authorized_keys
    
    [Install]
    WantedBy=multi-user.target
@@ -340,9 +343,12 @@ jobs:
         
       - name: Sync SSH keys on target servers
         run: |
+          # Add the server's host key to known_hosts before connecting
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "${{ secrets.SERVER_HOST }}" >> ~/.ssh/known_hosts
           # Download and run ssh-key-sync
           curl -fsSL https://raw.githubusercontent.com/locus313/ssh-key-sync/main/sync-ssh-keys.sh | \
-          ssh -o StrictHostKeyChecking=no deploy@${{ secrets.SERVER_HOST }} 'cat > sync-ssh-keys.sh && chmod +x sync-ssh-keys.sh && sudo ./sync-ssh-keys.sh'
+          ssh deploy@${{ secrets.SERVER_HOST }} 'cat > sync-ssh-keys.sh && chmod +x sync-ssh-keys.sh && sudo ./sync-ssh-keys.sh'
         env:
           GITHUB_TOKEN: ${{ secrets.SSH_SYNC_TOKEN }}
 ```
@@ -544,9 +550,6 @@ bash -n sync-ssh-keys.sh
 
 # With ShellCheck (recommended)
 shellcheck sync-ssh-keys.sh
-
-# Test with dry-run mode (if implemented)
-./sync-ssh-keys.sh --dry-run
 ```
 
 ### Test Coverage

--- a/TESTING.md
+++ b/TESTING.md
@@ -119,7 +119,7 @@ Various test configurations are used:
 - Empty user arrays
 - Error-inducing configurations
 
-### Mock Endpoints
+### External Test Endpoints
 Tests use real but safe endpoints:
 - `https://github.com/octocat.keys` - GitHub's mascot user
 - GitHub API endpoints for public repositories


### PR DESCRIPTION
This pull request updates the `README.md` and `TESTING.md` files to improve documentation clarity, update badges, and enhance security and automation instructions. The changes focus on making deployment and automation instructions clearer, improving security guidance, and refining testing documentation.

**Documentation improvements:**

* Updated the version badge in the `README.md` to use the GitHub release API for more accurate and automatic version reporting.
* Added a note clarifying that `users.conf` must be located in the same directory as `sync-ssh-keys.sh`, particularly when deploying to custom paths.

**Security and automation enhancements:**

* Improved the systemd service example by adding comments explaining `ProtectHome` and `ReadWritePaths`, clarifying their roles in controlling script access to home directories.
* Enhanced the GitHub Actions workflow example by adding a step to pre-populate `known_hosts` with the server's host key using `ssh-keyscan`, removing the less secure `StrictHostKeyChecking=no` option.

**Testing documentation updates:**

* Removed a reference to a dry-run test mode in the `README.md` (since it may not be implemented), and changed "Mock Endpoints" to "External Test Endpoints" in `TESTING.md` for more accurate terminology. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L547-L549) [[2]](diffhunk://#diff-4da5f2fd7bc2f11672282410e99aad91d422f9f4fb6c723abc7ef29ee5cb6906L122-R122)